### PR TITLE
Fix missing HELM_VALUES and add a note about remote host clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ In the example commands below, the HELM_VALUES variable will be populated with t
 export CLUSTER_NAME=vcluster
 export CLUSTER_NAMESPACE=vcluster
 export KUBERNETES_VERSION=1.23.0
+export HELM_VALUES=""
 # Uncomment if you want to use vcluster values
 # export HELM_VALUES=$(cat devvalues.yaml | sed -z 's/\n/\\n/g')
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -53,6 +54,7 @@ kubectl wait --for=condition=ready vcluster -n $CLUSTER_NAMESPACE $CLUSTER_NAME
 ```
 At this point the cluster is ready to be used. Please refer to the next chapter to get the credentials.
 
+**Note**: at the moment, the provider is able to host vclusters only in the cluster where the vcluter provider is running([management cluster](https://cluster-api.sigs.k8s.io/user/concepts.html#management-cluster)). Support for the remote host clusters is on our roadmap - [loft-sh/cluster-api-provider-vcluster#6](https://github.com/loft-sh/cluster-api-provider-vcluster/issues/6).
 
 # How to connect to your vcluster
 There are multiple methods for exposing your vcluster instance, and they are described in the [vcluster docs](https://www.vcluster.com/docs/operator/external-access). If you follow the docs exactly, you will need to use the vcluster CLI to retrieve kubeconfig. When using this CAPI provider you have an alternative - `clusterctl get kubeconfig ${CLUSTER_NAME} --namespace ${CLUSTER_NAMESPACE} > ./kubeconfig.yaml`, more details about this are in the [CAPI docs](https://cluster-api.sigs.k8s.io/clusterctl/commands/get-kubeconfig.html). Virtual cluster kube config will be written to: ./kubeconfig.yaml. You can access the cluster via `kubectl --kubeconfig ./kubeconfig.yaml get namespaces`.


### PR DESCRIPTION
The `export HELM_VALUES=""` line is needed because in the released version this is a required variable. We should probably make it optional.

Also adding a note about current limitations regarding host clusters for vcluster instance.