### PR TITLE
fix: bump the default vcluster chart version

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,7 @@ import "os"
 
 var (
 	// DefaultVClusterVersion is the default version of the virtual cluster to use
-	DefaultVClusterVersion = "0.7.1"
+	DefaultVClusterVersion = "0.11.1"
 
 	// DefaultVClusterChartName is the default chart name of the virtual cluster to use
 	DefaultVClusterChartName = "vcluster"


### PR DESCRIPTION
This fixes issues with Service CIDR, where the provider expects the chart to do the Service CIDR auto-discovery, but installs the old version of the chart, which does not have support for this.

I am creating this as a draft because vcluster 0.11.1 is not released yet.
To be merged as soon as it 0.11.1 is released. A new patch release of the provider should follow immediately. 