### PR TITLE
Upgrade helm to 3.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /workspace
 RUN if [ "${TARGETARCH}" = "amd64" ]; then go install github.com/go-delve/delve/cmd/dlv@latest; fi
 
 # Install Helm 3
-RUN curl -s https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz > helm3.tar.gz \
+RUN curl -s https://get.helm.sh/helm-v3.11.1-linux-amd64.tar.gz > helm3.tar.gz \
  && tar -zxvf helm3.tar.gz linux-amd64/helm \
  && chmod +x linux-amd64/helm \
  && mv linux-amd64/helm $PWD/helm \


### PR DESCRIPTION
The current helm version used can't handle the latest vcluster helm chart. Was not able to fully test this yet but AFAIK the helm CLI interface did not change in a breaking way.

Fixes #22