### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
-          echo "::set-output name=release_version::$RELEASE_VERSION"
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
       - name: Prepare all release files for the provider
         run: |
           make release TAG=$RELEASE_VERSION
@@ -45,7 +45,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
-          echo "::set-output name=release_version::$RELEASE_VERSION"
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
       - name: Get Docker tags
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v2
@@ -87,7 +87,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
-          echo "::set-output name=release_version::$RELEASE_VERSION"
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
       - uses: geertvdc/setup-hub@v1.0.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
-          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Prepare all release files for the provider
         run: |
           make release TAG=$RELEASE_VERSION
@@ -45,7 +45,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
-          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Get Docker tags
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v2
@@ -87,7 +87,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
-          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: geertvdc/setup-hub@v1.0.0
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


