### PR TITLE
fix: only initialize default namespace when given

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,13 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	var namespaces map[string]cache.Config
+	if namespace != "" {
+		namespaces = map[string]cache.Config{
+			namespace: {},
+		}
+	}
+
 	mgr, err := manager.New(ctrl.GetConfigOrDie(), manager.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -87,9 +94,7 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "4012c7fa.cluster.x-k8s.io",
 		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				namespace: {},
-			},
+			DefaultNamespaces: namespaces,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Otherwise the controller is not able to delete the vcluster.

Error message:
```go
2024-06-13T09:15:34Z    ERROR   Reconciler error        {"controller": "vcluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "VCluster", "VCluster": {"name":"vcluster","namespace":"vcluster"}, "namespace": "vcluster", "name": "vcluster", "reconcileID": "6f7c4b3b-e18c-4e48-8c9c-645ff95b708a", "error": "unable to list: vcluster because of unknown namespace for the cache"}
```