### PR TITLE
chore: run go install after a new release to populate the go proxy cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,3 +109,22 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.get_version.outputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+  go-install-release:
+    # We do this in order to populate the Go proxy cache, which is used by CAPI to discover new provider releases
+    if: startsWith(github.ref, 'refs/tags/v') == true
+    needs: [publish-release]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - id: get_version
+        run: |
+          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false
+      - name: Run go install
+        run: go install github.com/loft-sh/cluster-api-provider-vcluster@"$RELEASE_VERSION"


### PR DESCRIPTION
Resolves ENG-4357