### PR TITLE
chore: change registry of kube-rbac-proxy image

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.2
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -19,7 +19,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=0"
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Resolves ENG-5528

Context: https://github.com/loft-sh/cluster-api-provider-vcluster/issues/91
This uses Option 3 for now, as discussed in https://github.com/kubernetes-sigs/kubebuilder/discussions/3907