### PR TITLE
chore: run e2e tests with latest vcluster binary

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -76,7 +76,7 @@ jobs:
           sudo mv ./kubectl /usr/local/bin/kubectl
 
           # Install vcluster
-          curl -Lo vcluster https://github.com/loft-sh/vcluster/releases/download/v0.22.3/vcluster-linux-amd64
+          curl -Lo vcluster https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64
           chmod +x ./vcluster
           sudo mv ./vcluster /usr/local/bin/vcluster
 


### PR DESCRIPTION
Should be merged after https://github.com/loft-sh/cluster-api-provider-vcluster/pull/104

Part of ENG-3957