### PR TITLE
Expose VCluster Status Fields as printer columns

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -5,6 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ConditionType is a valid value for Condition.Type.
+type ConditionType string
+
 // Common ConditionTypes used by Cluster API objects.
 const (
 	// ReadyCondition defines the Ready condition type that summarizes the operational state of the vcluster API object.
@@ -23,6 +26,7 @@ const (
 // ConditionSeverity expresses the severity of a Condition Type failing.
 type ConditionSeverity string
 
+// Condition severity levels
 const (
 	// ConditionSeverityError specifies that a condition with `Status=False` is an error.
 	ConditionSeverityError ConditionSeverity = "Error"
@@ -39,9 +43,6 @@ const (
 
 // Conditions is an array of conditions
 type Conditions []Condition
-
-// ConditionType is a valid value for Condition.Type.
-type ConditionType string
 
 // Condition defines an observation of a Cluster API resource operational state.
 type Condition struct {

--- a/api/v1alpha1/vcluster_types.go
+++ b/api/v1alpha1/vcluster_types.go
@@ -43,10 +43,12 @@ type VClusterStatus struct {
 
 	// Ready defines if the virtual cluster control plane is ready.
 	// +optional
+	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
 	// Initialized defines if the virtual cluster control plane was initialized.
 	// +optional
+	// +kubebuilder:default=false
 	Initialized bool `json:"initialized"`
 
 	// Phase describes the current phase the virtual cluster is in
@@ -107,18 +109,30 @@ type VirtualClusterHelmChart struct {
 }
 
 // VirtualClusterPhase describes the phase of a virtual cluster
+// +kubebuilder:validation:Enum="";Pending;Deployed;Failed
 type VirtualClusterPhase string
 
-// These are the valid admin account types
 const (
-	VirtualClusterUnknown  VirtualClusterPhase = ""
-	VirtualClusterPending  VirtualClusterPhase = "Pending"
+	// VirtualClusterUnknown represents an unknown phase
+	VirtualClusterUnknown VirtualClusterPhase = ""
+
+	// VirtualClusterPending indicates the cluster is being created
+	VirtualClusterPending VirtualClusterPhase = "Pending"
+
+	// VirtualClusterDeployed indicates the cluster is fully deployed and operational
 	VirtualClusterDeployed VirtualClusterPhase = "Deployed"
-	VirtualClusterFailed   VirtualClusterPhase = "Failed"
+
+	// VirtualClusterFailed indicates the cluster deployment has failed
+	VirtualClusterFailed VirtualClusterPhase = "Failed"
 )
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.helmRelease.chart.version"
+//+kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready"
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VCluster is the Schema for the vclusters API
 type VCluster struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vclusters.yaml
@@ -14,7 +14,23 @@ spec:
     singular: vcluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.helmRelease.chart.version
+      name: Version
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VCluster is the Schema for the vclusters API
@@ -127,6 +143,7 @@ spec:
                   type: object
                 type: array
               initialized:
+                default: false
                 description: Initialized defines if the virtual cluster control plane
                   was initialized.
                 type: boolean
@@ -143,8 +160,14 @@ spec:
               phase:
                 description: Phase describes the current phase the virtual cluster
                   is in
+                enum:
+                - ""
+                - Pending
+                - Deployed
+                - Failed
                 type: string
               ready:
+                default: false
                 description: Ready defines if the virtual cluster control plane is
                   ready.
                 type: boolean


### PR DESCRIPTION
This PR exposes the already set status values and adds some validation and documentation.

changes:

- Add kubebuilder validation for VCluster status fields
  - Default values for Ready and Initialized fields (false)
  - Enum validation for Phase field
- Add additional printer columns for better `kubectl get vluster` output:
  - Version
  - Ready
  - Phase
  - Message
  - Age
