### PR TITLE
fix: set proper type for cluster api kubeconfig secret

### DIFF
--- a/controllers/vcluster_controller.go
+++ b/controllers/vcluster_controller.go
@@ -56,8 +56,7 @@ type ClientConfigGetter interface {
 	NewForConfig(restConfig *rest.Config) (kubernetes.Interface, error)
 }
 
-type clientConfigGetter struct {
-}
+type clientConfigGetter struct{}
 
 func (c *clientConfigGetter) NewForConfig(restConfig *rest.Config) (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(restConfig)
@@ -71,8 +70,7 @@ type HTTPClientGetter interface {
 	ClientFor(r http.RoundTripper, timeout time.Duration) *http.Client
 }
 
-type httpClientGetter struct {
-}
+type httpClientGetter struct{}
 
 func (h *httpClientGetter) ClientFor(r http.RoundTripper, timeout time.Duration) *http.Client {
 	return &http.Client{
@@ -414,12 +412,11 @@ func (r *VClusterReconciler) syncVClusterKubeconfig(ctx context.Context, vCluste
 			},
 		},
 		Type: clusterv1beta1.ClusterSecretType,
+		Data: map[string][]byte{
+			KubeconfigDataName: outKubeConfig,
+		},
 	}
 	_, err = controllerutil.CreateOrPatch(ctx, r.Client, kubeSecret, func() error {
-		if kubeSecret.Data == nil {
-			kubeSecret.Data = make(map[string][]byte)
-		}
-		kubeSecret.Data[KubeconfigDataName] = outKubeConfig
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
This PR includes an update to how the kubeconfig secrets are copied by setting the proper type so that cluster api can access it.

fixes the following error in cluster api:
```
cluster_accessor.go:257] "Connect failed" err="error creating REST config: error getting kubeconfig secret: Secret \"${CLUSTER_NAME}-kubeconfig\" not found" controller="clustercache" controllerGroup="cluster.x-k8s.io" controllerKind="Cluster" Cluster="default/test-hub-core-vc-1" namespace="${CLUSTER_NAMESPACE}" name="${CLUSTER_NAME}" reconcileID="752c4f5d-4bfe-4a47-af27-a207d627a63e"
```