### PR TITLE
refactor: Reduce unneccessary logging and add phase change logging

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -80,7 +80,6 @@ func (c *client) exec(args []string) error {
 		return nil
 	}
 
-	fmt.Println("helm " + strings.Join(args, " "))
 	cmd := exec.Command(c.helmPath, args...)
 	if c.stdout != nil {
 		cmd.Stdout = c.stdout


### PR DESCRIPTION
Changing the logging so that there is less noise and the logs are more useful.

- add logging for phase transition
- remove old deployment logging (would be called 4x not usefule)
- recreated deployment logging so that it is only called once.

