### PR TITLE
feat: Add kubernetes version to status

### DIFF
--- a/api/v1alpha1/vcluster_types.go
+++ b/api/v1alpha1/vcluster_types.go
@@ -72,6 +72,10 @@ type VClusterStatus struct {
 	// ObservedGeneration is the latest generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// KubernetesVersion is the version of Kubernetes running in the virtual cluster
+	// +optional
+	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
 }
 
 // GetConditions returns the set of conditions for this object.

--- a/controllers/vcluster_controller.go
+++ b/controllers/vcluster_controller.go
@@ -471,6 +471,20 @@ func (r *VClusterReconciler) checkReadyz(vCluster *v1alpha1.VCluster, restConfig
 		return false, nil
 	}
 
+	// If readiness check passed, get the version info
+	kubeClient, err := r.ClientConfigGetter.NewForConfig(restConfig)
+	if err != nil {
+		return true, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	version, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return true, fmt.Errorf("failed to get kubernetes version: %w", err)
+	}
+
+	// Update the status with version information
+	vCluster.Status.KubernetesVersion = version.GitVersion
+
 	return true, nil
 }
 


### PR DESCRIPTION
info: this stacked off of https://github.com/loft-sh/cluster-api-provider-vcluster/pull/100 so when that is merged this will need to be synced.

since it adds extra logic to get the kubernetes version i figured it would be better off in a separate PR.

this PR adds a `KubernetesVersion` field to the `VClusterStatus` which is set from the client getting the server's version (git version) (which i think should distinguish between k8s/k3s/k0s(truthfully i havent tested k0s yet))

```
k get vcluster -n vcluster
NAME        VERSION   KUBERNETESVERSION   READY   PHASE      MESSAGE                                                                                                                                                            AGE
vcluster1   0.22.1    v1.31.1+k3s1        true    Deployed                                                                                                                                                                      3h
vcluster3   0.22.1    v1.32.0             true    Deployed                                                                                                                                                                      3h
vcluster4   0.22.1    v1.32.0             true    Deployed                                                                                                                                                                      3h
vcluster5   0.22.3    v1.32.0             true    Failed     error installing / upgrading vcluster: error executing helm upgrade: Error: chart "vcluster" version "0.22.33" not found in https://charts.loft.sh repository...   3h
```
