### PR TITLE
chore: use latest if CHART_VERSION is not set

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -118,7 +118,6 @@ jobs:
         run: |
           export CLUSTER_NAME=vcluster-k3s
           export CLUSTER_NAMESPACE=vcluster-k3s
-          export CHART_VERSION=0.22.1
           export VCLUSTER_YAML=$(cat ./test/e2e/k3s-values.yaml | sed -z 's/\n/\\n/g')
           kubectl create namespace ${CLUSTER_NAMESPACE}
           cat templates/cluster-template.yaml | ./bin/envsubst | kubectl apply -n ${CLUSTER_NAMESPACE} -f -
@@ -139,7 +138,6 @@ jobs:
         run: |
           export CLUSTER_NAME=vcluster-k0s
           export CLUSTER_NAMESPACE=vcluster-k0s
-          export CHART_VERSION=0.22.1
           export CHART_NAME=vcluster
           export VCLUSTER_YAML=$(cat ./test/e2e/k0s-values.yaml | sed -z 's/\n/\\n/g')
           kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -161,7 +159,6 @@ jobs:
         run: |
           export CLUSTER_NAME=vcluster-k8s
           export CLUSTER_NAMESPACE=vcluster-k8s
-          export CHART_VERSION=0.22.1
           export CHART_NAME=vcluster
           export VCLUSTER_YAML=$(cat ./test/e2e/k8s-values.yaml | sed -z 's/\n/\\n/g')
           kubectl create namespace ${CLUSTER_NAMESPACE}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ clusterctl init --infrastructure vcluster
 
 Next you will generate a manifest file for a vcluster instance and create it in the management cluster.
 Cluster instance is configured using clusterctl parameters and environment variables - CHART_NAME, CHART_REPO, CHART_VERSION, VCLUSTER_HOST and VCLUSTER_PORT.
-In the example commands below, the VCLUSTER_YAML variable will be populated with the contents of the `values.yaml` file.
+In the example commands below will install the latest vcluster chart (because CHART_VERSION was omitted) and the VCLUSTER_YAML variable will be populated with the contents of the `values.yaml` file.
 ```shell
 export CLUSTER_NAME=vcluster
 export CLUSTER_NAMESPACE=vcluster
@@ -105,13 +105,11 @@ spec:
       # vcluster, and the "/charts/k3s" folder in the vcluster GitHub repo.
       # Other available options currently are: "vcluster-k8s", "vcluster-k0s" and "vcluster-eks".
       name: ${CHART_NAME:=vcluster}
-      # By default, a particular vcluster version is used in a given CAPVC release. You may find
-      # it out from the source code, e.g.: 
-      # https://github.com/loft-sh/cluster-api-provider-vcluster/blob/v0.1.3/pkg/constants/constants.go#L7
+      # By default the latest stable vcluster version is used.
       #
       # Please refer to the vcluster Releases page for the list of the available versions:
       # https://github.com/loft-sh/vcluster/releases
-      version: ${CHART_VERSION:=0.22.1}
+      version: ${CHART_VERSION:=""}
 
   # controlPlaneEndpoint represents the endpoint used to communicate with the control plane.
   # You may leave this field empty, and then CAPVC will try to fill in this information based
@@ -160,12 +158,11 @@ go run -mod vendor main.go
 ```
 
 Next, in a separate terminal you will generate a manifest file for a vcluster instance.
-Cluster instance is configured from a template file using environment variables - CLUSTER_NAME, CHART_NAME, CHART_REPO, CHART_VERSION, VCLUSTER_HOST and VCLUSTER_PORT. Only the CHART_VERSION and CLUSTER_NAME variables are mandatory.
+Cluster instance is configured from a template file using environment variables - CLUSTER_NAME, CHART_NAME, CHART_REPO, CHART_VERSION, VCLUSTER_HOST and VCLUSTER_PORT. Only the CLUSTER_NAME variable is mandatory.
 In the example commands below, the VCLUSTER_YAML variable will be populated with the contents of the `devvalues.yaml` file, don't forget to re-run the `export VCLUSTER_YAML...` command when the `devvalues.yaml` changes.
 ```shell
 export CLUSTER_NAME=test
 export CLUSTER_NAMESPACE=test
-export CHART_VERSION=0.22.1
 export CHART_NAME=vcluster
 export VCLUSTER_YAML=$(cat devvalues.yaml | awk '{printf "%s\\n", $0}')
 kubectl create namespace ${CLUSTER_NAMESPACE}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -22,7 +22,7 @@ spec:
     chart: 
       name: ${CHART_NAME:=vcluster}
       repo: ${CHART_REPO:=https://charts.loft.sh}
-      version: ${CHART_VERSION:=0.22.1}
+      version: ${CHART_VERSION:=""}
   controlPlaneEndpoint:
     host: ${VCLUSTER_HOST:=""}
     port: ${VCLUSTER_PORT:=0}


### PR DESCRIPTION
Resolves ENG-3957

Instead of explicitly bumping the CHART_VERSION (triggered from a vcluster release, see: https://github.com/loft-sh/vcluster/pull/2417 and https://github.com/loft-sh/cluster-api-provider-vcluster/pull/95), this PR changes the logic so that the controller will use the latest stable vcluster chart when CHART_VERSION is omitted.

TODO after merge:
- [ ] Merge https://github.com/loft-sh/cluster-api-provider-vcluster/pull/98